### PR TITLE
Move debug from dev to regular dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dyson-purelink",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Control Dyson PureLink fan/purifier devices from JavaScript",
   "main": "index.js",
   "scripts": {
@@ -10,11 +10,9 @@
   "license": "MIT",
   "dependencies": {
     "bonjour": "^3.5.0",
+    "debug": "^2.6.8",
     "mqtt": "^2.9.1",
     "request": "^2.81.0",
     "request-promise-native": "^1.0.4"
-  },
-  "devDependencies": {
-    "debug": "^2.6.8"
   }
 }


### PR DESCRIPTION
The app depends on the `debug` module and will crash if it is not installed.